### PR TITLE
Allow flexibility in running bare vm-base containers

### DIFF
--- a/image/base/create-vm-container.sh
+++ b/image/base/create-vm-container.sh
@@ -1,0 +1,35 @@
+BASE_IMAGE_HOST=~/ranchervm-images
+
+VM_NAME=$1
+IMAGE=$2
+
+[ -z "$1" ] && IMAGE=rancheros
+
+
+die(){
+	echo $1
+	exit 1
+}
+if [ -z "$VM_NAME" ]; then
+	die "Usage: $0 vm_name [image]"
+fi
+
+
+if [ ! -f "$BASE_IMAGE_HOST/$IMAGE" ]; then
+	die "Error: no image dir $BASE_IMAGE_HOST/$IMAGE"
+fi
+
+NEW_ID=$(docker run -d -e RANCHER_VM=true \
+	--cap-add NET_ADMIN \
+	-e IMAGE=$IMAGE \
+	-v $BASE_IMAGE_HOST:/base_image \
+	-v /tmp/ranchervm:/ranchervm \
+	--device /dev/kvm:/dev/kvm \
+	--device /dev/net/tun:/dev/net/tun \
+	--name $VM_NAME \
+	rancher/vm-base)
+
+echo "Created container $NEW_ID"
+sleep 1
+docker logs $NEW_ID
+

--- a/image/base/create-vm-container.sh
+++ b/image/base/create-vm-container.sh
@@ -15,7 +15,7 @@ if [ -z "$VM_NAME" ]; then
 fi
 
 
-if [ ! -f "$BASE_IMAGE_HOST/$IMAGE" ]; then
+if [ ! -e "$BASE_IMAGE_HOST/$IMAGE" ]; then
 	die "Error: no image dir $BASE_IMAGE_HOST/$IMAGE"
 fi
 

--- a/image/base/fetch-images.sh
+++ b/image/base/fetch-images.sh
@@ -1,0 +1,16 @@
+IMAGEDIR=~/ranchervm-images/
+cat imagelist.txt | grep -v "^#" | while read ENTRY; do
+	ALIAS=$(echo $ENTRY | cut -d' ' -f1)
+	URL=$(echo $ENTRY | cut -d' ' -f2)
+	FILENAME=$(basename "$URL")
+	echo filename $FILENAME
+	echo url $URL
+	if [ -z "$ALIAS" ] || [ -z "$URL" ] || [ -z "$FILENAME" ]; then
+		echo "config file entry is incorrect: $ENTRY"
+		exit 1
+	fi
+
+	wget "$URL" -O $IMAGEDIR/$FILENAME && \
+	ln -s $FILENAME $IMAGEDIR/$ALIAS || \
+	echo "download failed for url $URL"
+done

--- a/image/base/imagelist.txt
+++ b/image/base/imagelist.txt
@@ -1,0 +1,6 @@
+# space separated list of images
+# format: <name> <url>
+#android https://s3-us-west-1.amazonaws.com/sheng/qcow2/android-4.4-r2.gz.qcow2
+ubuntu https://s3-us-west-1.amazonaws.com/sheng/qcow2/ubuntu-14.04-amd64.img
+rancheros https://s3-us-west-1.amazonaws.com/sheng/qcow2/rancheros-0.3.0-gz.img
+#centos https://s3-us-west-1.amazonaws.com/sheng/qcow2/centos.7-1.x86-64.20150401.qcow2

--- a/image/base/startvm
+++ b/image/base/startvm
@@ -19,16 +19,26 @@ fi
 # Pass Docker command args to kvm
 KVM_ARGS=$@
 
+BASEDIR=/base_image
+
+BASE_IMAGE_PATH=$BASEDIR/$IMAGE
+
+BASE_IMAGE_FILE=$BASE_IMAGE_PATH
+# use $IMAGE subdir/file if supplied. 
+# if resulting BASE_IMAGE is a dir, use the first file found.
+if [ -d "$BASE_IMAGE_PATH" ]; then
+  # use the first file as base image
+  BASE_IMAGE_FILE=$BASEDIR/$(ls -p $BASE_IMAGE_PATH | grep -v "/" | head -n1)
+  echo "Specified image $BASE_IMAGE_PATH is a directory. Using file $BASE_IMAGE_FILE"
+fi
+
+# resolve symlink as 'qemu-img create' doesn't like symlink
+BASE_IMAGE_FILE=$(readlink -e $BASE_IMAGE_FILE)
+
 # Create the qcow disk image on the Docker volume named /image, using
 # the compressed qcow image that came with Docker image as the base.
 # Docker volumes typically perform better than the file system for
 # Docker images (no need for overlay fs etc.)
-
-BASE_IMAGE_DIR_LIST=( `ls /base_image` )
-if [ ${#BASE_IMAGE_DIR_LIST[@]} -ne 1 ]; then
-  echo "/base_image directory must contain exactly one base image file"
-  exit 1
-fi
 
 if [ ! -d "/image" ]; then
   echo "/image directory does not exist, failed to mount volume /image?"
@@ -37,7 +47,7 @@ fi
 
 KVM_IMAGE=/image/sda.qcow2
 if [ ! -f "$KVM_IMAGE" ]; then
-  qemu-img create -f qcow2 -b /base_image/${BASE_IMAGE_DIR_LIST[0]} \
+  qemu-img create -f qcow2 -b $BASE_IMAGE_FILE \
   $KVM_IMAGE > /dev/null
   if [[ $? -ne 0 ]]; then
     echo "Failed to create qcow2 image"

--- a/image/base/startvm
+++ b/image/base/startvm
@@ -2,6 +2,12 @@
 
 #set -x
 
+# For debugging
+if [ "$1" = "bash" ]; then
+  exec bash
+fi
+
+
 # These two variables can be overwritten
 
 : ${KVM_BLK_OPTS:="-drive file=\$KVM_IMAGE,if=none,id=drive-disk0,format=qcow2 \
@@ -9,10 +15,6 @@
 : ${KVM_NET_OPTS:="-netdev bridge,br=\$BRIDGE_IFACE,id=net0 \
 -device virtio-net-pci,netdev=net0,mac=\$MAC"}
 
-# For debugging
-if [ "$1" = "bash" ]; then
-  exec bash
-fi
 
 # Pass Docker command args to kvm
 KVM_ARGS=$@
@@ -48,8 +50,25 @@ fi
 # 1. Create a bridge named br0
 # 2. Remove IP from eth0, save eth0 MAC, give eth0 a random MAC
 
-IFACE=eth0
-BRIDGE_IFACE=br0
+function atoi
+{
+  #Returns the integer representation of an IP arg, passed in ascii dotted-decimal notation (x.x.x.x)
+  IP=$1; IPNUM=0
+  for (( i=0 ; i<4 ; ++i )); do
+  ((IPNUM+=${IP%%.*}*$((256**$((3-${i}))))))
+  IP=${IP#*.}
+  done
+  echo $IPNUM 
+} 
+ 
+function itoa
+{
+  #returns the dotted-decimal ascii form of an IP arg passed in integer format
+  echo -n $(($(($(($((${1}/256))/256))/256))%256)).
+  echo -n $(($(($((${1}/256))/256))%256)).
+  echo -n $(($((${1}/256))%256)).
+  echo $((${1}%256)) 
+}
 
 cidr2mask() {
   local i mask=""
@@ -69,6 +88,11 @@ cidr2mask() {
 
   echo $mask
 }
+
+
+IFACE=eth0
+BRIDGE_IFACE=br0
+
 
 MAC=`ip addr show $IFACE | grep ether | sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*\$//g' | cut -f2 -d ' '`
 IP=`ip addr show dev $IFACE | grep "inet $IP_PREFIX" | awk '{print $2}' | cut -f1 -d/`
@@ -98,26 +122,6 @@ NEWMAC=`echo 06:FE$end`
 
 let "NEWCIDR=$CIDR-1"
 #NEWNETMASK=`cidr2mask $NEWCIDR`
-
-function atoi
-{
-#Returns the integer representation of an IP arg, passed in ascii dotted-decimal notation (x.x.x.x)
-IP=$1; IPNUM=0
-for (( i=0 ; i<4 ; ++i )); do
-((IPNUM+=${IP%%.*}*$((256**$((3-${i}))))))
-IP=${IP#*.}
-done
-echo $IPNUM 
-} 
- 
-function itoa
-{
-#returns the dotted-decimal ascii form of an IP arg passed in integer format
-echo -n $(($(($(($((${1}/256))/256))/256))%256)).
-echo -n $(($(($((${1}/256))/256))%256)).
-echo -n $(($((${1}/256))%256)).
-echo $((${1}%256)) 
-}
  
 i=`atoi $IP`
 let "i=$i^(1<<$CIDR)"


### PR DESCRIPTION
Hi Sheng,

I think RancherVM is great, the startvm script helped me a lot in getting containers to run. I am forking RancherVm and I'd like to have your opinion on the following approach, to see if it makes sense to keep contributing to upstream.

I'm arguing that putting the vm base images in the containers is user friendly for the Proof-of-Concept, until you want to run other images (which you often want). Then the user is burdened with managing a docker repo to push to, or build the images himself. So the data management problem is then moved to managing docker repo's. 

My approach is based on 2 ideas: 
1. For many use cases you want to manage your images with another way than inside the containers (e.g. separate docker volumes, or just on the host)
2. you want to be able to volume-mount a directory with multiple vm-image files, and specify which one to use. 

Do you think this makes sense? 

If so, properties of the proposed changes: 
- backwards compatible with the rancheros/ubuntu/centos sub-images
- allow running vm-base with an -e IMAGE variable that specifies the file name or directory relative to /base-image . 
- if /base_image/$IMAGE is a directory, use the first file as listed by ls -1  . 
- if /base_image/$IMAGE is a symlink, resolve it so that the qcow2 chain works fine
  (reason for the above to is allow for more flexible qcow2 image chains)
