### PR TITLE
Enable RancherVM to accept additional block devices as volume

### DIFF
--- a/image/base/Makefile
+++ b/image/base/Makefile
@@ -1,5 +1,5 @@
 NAME = rancher/vm-base
-VERSION = 0.0.1
+VERSION = 0.0.2
 
 .PHONY : all clean build
 

--- a/image/base/startvm
+++ b/image/base/startvm
@@ -43,6 +43,15 @@ if [ ! -f "$KVM_IMAGE" ]; then
   fi
 fi
 
+VOLUMES_DIR="/volumes/"
+VOLUMES_LIST=`find $VOLUMES_DIR -name "*.img"`
+extra_kvm_blk_opts=""
+for volume in $VOLUMES_LIST
+do
+	extra_kvm_blk_opts=$extra_kvm_blk_opts" -drive file=$volume,if=virtio"
+done
+KVM_BLK_OPTS=$KVM_BLK_OPTS$extra_kvm_blk_opts
+
 # Network setup:
 #
 # 1. Create a bridge named br0


### PR DESCRIPTION
Volumes would be present at /volumes/ directory, e.g. /volumes/vol1. It would be
a raw image file inside and can be used by VM.
