### PR TITLE
Document default creds

### DIFF
--- a/image/centos/.dockerignore
+++ b/image/centos/.dockerignore
@@ -1,0 +1,1 @@
+README.md

--- a/image/centos/README.md
+++ b/image/centos/README.md
@@ -1,0 +1,3 @@
+## Default credentials:
+- Username: `root`
+- Password: `password`

--- a/image/ubuntu/.dockerignore
+++ b/image/ubuntu/.dockerignore
@@ -1,0 +1,1 @@
+README.md

--- a/image/ubuntu/README.md
+++ b/image/ubuntu/README.md
@@ -1,0 +1,3 @@
+## Default credentials:
+- Username: `ubuntu`
+- Password: `ubuntu`


### PR DESCRIPTION
This documents the default login creds for the ubuntu and centos images in a README.md file in the appropriate directory.

This addresses #59 
