### PR TITLE
Don't pass MAC address to tapclient

### DIFF
--- a/image/base/Dockerfile
+++ b/image/base/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:14.04.2
 RUN apt-get update && \
     apt-get install -y qemu-kvm dnsmasq \
 		       bridge-utils genisoimage curl jq
-ADD https://github.com/rancher/vmnet/releases/download/v0.1.0/tapclient /usr/bin/
+ADD https://github.com/rancher/vmnet/releases/download/v0.2.0/tapclient /usr/bin/
 RUN chmod +x /usr/bin/tapclient
 COPY startvm /var/lib/rancher/startvm
 ENTRYPOINT ["/var/lib/rancher/startvm"]

--- a/image/base/startvm
+++ b/image/base/startvm
@@ -27,7 +27,7 @@ fetch_rancher()
 	name=$1
 	file=$2
 
-	curl -s http://rancher-metadata/2015-07-25/self/container/labels/$name > $file
+	curl -s http://169.254.169.250/2015-07-25/self/container/labels/$name > $file
 	if [ $? -ne 0 ]
 	then
 		return
@@ -209,9 +209,9 @@ cidr2mask() {
 }
 
 setup_tap() {
-    MAC=`ip addr show $IFACE | grep ether | sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*\$//g' | cut -f2 -d ' ' | sed s/^02:/04:/`
+    MAC=`ip addr show $IFACE | grep ether | sed -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*\$//g' | cut -f2 -d ' '`
     ip link set dev eth0 down
-    LAUNCHER="tapclient --mac=$MAC --"
+    LAUNCHER="tapclient --"
     KVM_NET_OPTS="-netdev tap,fd=%FD%,id=hostnet0 -device virtio-net-pci,netdev=hostnet0,id=net0,mac=$MAC"
 }
 
@@ -220,7 +220,10 @@ setup_bridge_networking() {
     IP=`ip addr show dev $IFACE | grep "inet $IP" | awk '{print $2}' | cut -f1 -d/`
     CIDR=`ip addr show dev $IFACE | grep "inet $IP" | awk '{print $2}' | cut -f2 -d/`
     NETMASK=`cidr2mask $CIDR`
-    if [ -z "$GATEWAY" ]; then
+    if [ "$RANCHER_NETWORK" = "true" ]
+    then
+        GATEWAY=$(curl -s http://169.254.169.250/2015-07-25/self/container/labels/io.rancher.vm.metadata | jq -r '.["local-ipv4-gateway"]')
+    else
         GATEWAY=`ip route get 8.8.8.8 | grep via | cut -f3 -d ' '`
     fi
     NAMESERVER=( `grep nameserver /etc/resolv.conf | grep -v "#" | cut -f2 -d ' '` )
@@ -272,35 +275,6 @@ EOF
 
     echo allow $BRIDGE_IFACE >  /etc/qemu/bridge.conf
 }
-
-RETRY_TIMES=10
-RETRY_INTERVAL=5
-IP=""
-if [ "$RANCHER_NETWORK" = "true" ]
-then
-	ready=0
-	for i in `seq 1 $RETRY_TIMES`
-	do
-		IP=`curl -s http://rancher-metadata/2015-07-25/self/container/primary_ip`
-		if [ $? -eq 0 ]
-		then
-			tmp=`ip addr show dev $IFACE | grep "inet $IP"`
-			if [ $? -eq 0 ]
-			then
-				ready=1
-				break
-			fi
-		fi
-		echo Waiting to get ip with Rancher network
-		sleep $RETRY_INTERVAL
-	done
-	if [ $ready -eq 0 ]
-	then
-		echo "Fail to get the ip address in Rancher network"
-		exit 1
-	fi
-	GATEWAY=$(curl -s http://rancher-metadata/2015-07-25/self/container/labels/io.rancher.vm.metadata | jq -r '.["local-ipv4-gateway"]')
-fi
 
 # need to wait until network is ready
 ISO=`generate_cloud_drive`


### PR DESCRIPTION
Additionally if we are running in the context of Rancher we can't use
DNS because Rancher will not inject DNS to VMs.  This means we use the
rancher-metadata IP and not the DNS name.  As a consequence we also
don't need to wait for metadata to be available.  It will always be
available on start.
