### PR TITLE
Fix IP generation for automatic bridge device

### DIFF
--- a/image/base/startvm
+++ b/image/base/startvm
@@ -251,7 +251,7 @@ EOF
     #NEWNETMASK=`cidr2mask $NEWCIDR`
 
     i=`atoi $IP`
-    let "i=$i^(1<<$CIDR)"
+    let "i=$i^(1<<(32-$CIDR))"
     NEWIP=`itoa i`
 
     ip link set dev $IFACE down


### PR DESCRIPTION
Previously, the IP was generated in a network that would not encompass container's original IP: It only worked for /16 networks :)

To illustrate, with the previous incarnation:
192.168.123.2/24 would become 19**3**.168.123.2/23, not very useful because the latter does not include the former.
OTOH with the fix
192.168.123.2/24 would become 192.168.12**2**.2/23 which does actually include the former IP.
