### PR TITLE
fix ranchervm-backend service type

### DIFF
--- a/hack/deploy.yaml
+++ b/hack/deploy.yaml
@@ -174,7 +174,7 @@ spec:
     port: 9500
   selector:
     app: ranchervm-backend
-  type: NodePort
+  type: ClusterIP
 ---
 apiVersion: apps/v1beta1
 kind: Deployment


### PR DESCRIPTION
change `nodeport` to `ClusterIP`