### PR TITLE
Hack to fix bridge devices

### DIFF
--- a/image/vm-tools/startvm
+++ b/image/vm-tools/startvm
@@ -31,7 +31,8 @@ gen_mac() {
 }
 
 # These variables can be overwritten
-: ${IFACE:="eth0"}
+IFACE=$(ls /sys/class/net/ | grep -e '^e' | head -1)
+# : ${IFACE:="eth0"}
 : ${BRIDGE_IFACE:="br0"}
 : ${MEMORY_MB:="128"}
 : ${CPUS:="1"}


### PR DESCRIPTION
- Instead of receiving the bridge device from the global configuration, try to autodetect the device each time
- This will use the first Ethernet device in `/sys/class/net` (alphabetically)

I don't think this is the best fix, but it should work on most modern Linux systems. If there are more than one Ethernet devices, then it may or may not do the right thing.

For #102 