### PR TITLE
kvm extra arguments and hugepages support

### DIFF
--- a/image/vm-tools/Dockerfile
+++ b/image/vm-tools/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
 
-COPY RancherVM-debootstrap-ubuntu-1604.tgz /opt/rancher/vm-tools/
+COPY RancherVM-debootstrap-ubuntu-1804.tgz /opt/rancher/vm-tools/
 COPY startvm /opt/rancher/vm-tools/
 COPY start.sh /usr/bin/
 

--- a/image/vm-tools/Dockerfile
+++ b/image/vm-tools/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 COPY RancherVM-debootstrap-ubuntu-1804.tgz /opt/rancher/vm-tools/
 COPY startvm /opt/rancher/vm-tools/

--- a/image/vm-tools/Makefile
+++ b/image/vm-tools/Makefile
@@ -1,6 +1,6 @@
 NAME = nsonetwork30/vm-tools
 VERSION = v0.1.0
-BASE_IMAGE=RancherVM-debootstrap-ubuntu-1604.tgz
+BASE_IMAGE=RancherVM-debootstrap-ubuntu-1804.tgz
 
 .PHONY : all clean build
 

--- a/image/vm-tools/Makefile
+++ b/image/vm-tools/Makefile
@@ -1,4 +1,4 @@
-NAME = rancher/vm-tools
+NAME = nsonetwork30/vm-tools
 VERSION = v0.1.0
 BASE_IMAGE=RancherVM-debootstrap-ubuntu-1604.tgz
 

--- a/image/vm-tools/debootstrap.sh
+++ b/image/vm-tools/debootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-TARGET_ROOTFS_DIR=/tmp/rootfs/RancherVM-debootstrap-ubuntu-1604
+TARGET_ROOTFS_DIR=/tmp/rootfs/RancherVM-debootstrap-ubuntu-1804
 mkdir -p ${TARGET_ROOTFS_DIR}
 
 INCLUDE_PKGS="vim,qemu-kvm,qemu-utils,bridge-utils,genisoimage,curl,net-tools"
@@ -9,7 +9,7 @@ debootstrap \
   --arch=amd64 \
   --variant=minbase \
   --include="${INCLUDE_PKGS}" \
-  xenial \
+  bionic \
   ${TARGET_ROOTFS_DIR} \
   http://archive.ubuntu.com/ubuntu/
 

--- a/image/vm-tools/start.sh
+++ b/image/vm-tools/start.sh
@@ -7,7 +7,7 @@ fi
 
 if [ ! -f /vm-tools/.success ]; then
   echo "Extracting filesystem to volume mounted at /vm-tools"
-  tar xzf /opt/rancher/vm-tools/RancherVM-debootstrap-ubuntu-1604.tgz -C /vm-tools
+  tar xzf /opt/rancher/vm-tools/RancherVM-debootstrap-ubuntu-1804.tgz -C /vm-tools
   cp /opt/rancher/vm-tools/startvm /vm-tools/usr/bin/startvm
 
   echo "Extraction successful"

--- a/image/vm-tools/startvm
+++ b/image/vm-tools/startvm
@@ -308,4 +308,4 @@ exec $LAUNCHER qemu-system-x86_64 \
   -qmp unix:/vm/${MY_POD_NAME}_monitor.sock,server,nowait \
   $VNC \
   `eval echo $KVM_BLK_OPTS` \
-  `eval echo $KVM_NET_OPTS` $KVM_ARGS
+  `eval echo $KVM_NET_OPTS` $KVM_ARGS $KVM_EXTRA_ARGS

--- a/pkg/apis/ranchervm/v1alpha1/types.go
+++ b/pkg/apis/ranchervm/v1alpha1/types.go
@@ -48,6 +48,9 @@ type VirtualMachineSpec struct {
 	// This is mutable at runtime and will trigger a live migration.
 	// +optional
 	NodeName string `json:"node_name"`
+        KvmArgs string `json:"kvm_extra_args"`
+        ImageVMTools string `json:"image_vmtools"`
+
 }
 
 type StateType string

--- a/pkg/apis/ranchervm/v1alpha1/types.go
+++ b/pkg/apis/ranchervm/v1alpha1/types.go
@@ -50,6 +50,7 @@ type VirtualMachineSpec struct {
 	NodeName string `json:"node_name"`
         KvmArgs string `json:"kvm_extra_args"`
         ImageVMTools string `json:"image_vmtools"`
+        UseHugePages bool `json:"use_hugepages"`
 
 }
 

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -50,6 +50,17 @@ func MakeVolEmptyDir(name string) corev1.Volume {
 	}
 }
 
+func MakeVolEmptyDirHugePages(name string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{
+                                Medium: corev1.StorageMediumHugepages,
+                        },
+		},
+	}
+}
+
 func MakeVolHostPath(name, path string) corev1.Volume {
 	return corev1.Volume{
 		Name: name,

--- a/pkg/controller/vm/util.go
+++ b/pkg/controller/vm/util.go
@@ -95,7 +95,7 @@ func (ctrl *VirtualMachineController) makeVMPod(vm *v1alpha1.VirtualMachine, ifa
 		VolumeMounts: []corev1.VolumeMount{
 			common.MakeVolumeMount("vm-image", "/image", "", false),
 			common.MakeVolumeMount("dev-kvm", "/dev/kvm", "", false),
-			common.MakeVolumeMount("dev-hugepages", "/dev/hugepages", "", false),
+			common.MakeVolumeMount("hugepages", "/hugepages", "", false),
 			common.MakeVolumeMount("vm-socket", "/vm", "", false),
 			common.MakeVolumeMount("vm-fs", "/bin", "bin", true),
 			// kubernetes mounts /etc/hosts, /etc/hostname, /etc/resolv.conf
@@ -125,6 +125,8 @@ func (ctrl *VirtualMachineController) makeVMPod(vm *v1alpha1.VirtualMachine, ifa
 				corev1.ResourceMemory: *resource.NewQuantity(int64(vm.Spec.MemoryMB)*1024*1024, resource.BinarySI),
 				// Volume size, in bytes (e,g. 5Gi = 5GiB = 5 * 1024 * 1024 * 1024)
 				// corev1.ResourceStorage: *resource.NewQuantity(8*1024*1024*1024, resource.BinarySI),
+				// Memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024)
+				corev1.ResourceHugePagesPrefix+"2Mi": *resource.NewQuantity(int64(vm.Spec.MemoryMB)*1024*1024, resource.BinarySI),
 			},
 		}
 	}
@@ -162,7 +164,7 @@ func (ctrl *VirtualMachineController) makeVMPod(vm *v1alpha1.VirtualMachine, ifa
 				common.MakeHostStateVol(vm.Name, "vm-image"),
 				common.MakeVolHostPath("vm-socket", fmt.Sprintf("%s/%s", common.HostStateBaseDir, vm.Name)),
 				common.MakeVolHostPath("dev-kvm", "/dev/kvm"),
-				common.MakeVolHostPath("dev-hugepages", "/dev/hugepages"),
+				common.MakeVolEmptyDirHugePages("hugepages"),
 			},
 			InitContainers: []corev1.Container{
 				corev1.Container{

--- a/pkg/controller/vm/util.go
+++ b/pkg/controller/vm/util.go
@@ -95,6 +95,7 @@ func (ctrl *VirtualMachineController) makeVMPod(vm *v1alpha1.VirtualMachine, ifa
 		VolumeMounts: []corev1.VolumeMount{
 			common.MakeVolumeMount("vm-image", "/image", "", false),
 			common.MakeVolumeMount("dev-kvm", "/dev/kvm", "", false),
+			common.MakeVolumeMount("dev-hugepages", "/dev/hugepages", "", false),
 			common.MakeVolumeMount("vm-socket", "/vm", "", false),
 			common.MakeVolumeMount("vm-fs", "/bin", "bin", true),
 			// kubernetes mounts /etc/hosts, /etc/hostname, /etc/resolv.conf
@@ -161,6 +162,7 @@ func (ctrl *VirtualMachineController) makeVMPod(vm *v1alpha1.VirtualMachine, ifa
 				common.MakeHostStateVol(vm.Name, "vm-image"),
 				common.MakeVolHostPath("vm-socket", fmt.Sprintf("%s/%s", common.HostStateBaseDir, vm.Name)),
 				common.MakeVolHostPath("dev-kvm", "/dev/kvm"),
+				common.MakeVolHostPath("dev-hugepages", "/dev/hugepages"),
 			},
 			InitContainers: []corev1.Container{
 				corev1.Container{


### PR DESCRIPTION
The purpose of this pull request is to make ranchervm able to run high performance VM meant to be
used network virtual function.
One of the requirement for network virtual function is to leverage SRIOV for multiple network interfaces.
By consequences, the qemu hypervisor has to be configured to use multiple VFIO type interfaces and hugepages memory backing.
This pull request is to propose to add properties to the kubernetes VM object.
image_vmtools property to specify an alternate vm-tools image (which would contain a customized startvm script)
kvm_extra_args property to specify additional parameters to be passed to qemu (-mem-path, -mem-prealloc, multiple VFIO interfaces,...)
use_hugepages property to trigger the use of hugepages as medium for an "empty dir" volume used as "-mem-path" by qemu
Here is an example of a VM making use of those new properties
```javascript

kubectl get vm t2 -o yaml
apiVersion: vm.rancher.io/v1alpha1
kind: VirtualMachine
metadata:
  clusterName: ""
  creationTimestamp: 2018-09-10T14:47:19Z
  finalizers:
  - deletion.vm.rancher.io
  generation: 1
  name: t2
  namespace: ""
  resourceVersion: "4225120"
  selfLink: /apis/vm.rancher.io/v1alpha1/virtualmachines/t2
  uid: 6ac30d2a-b508-11e8-aa28-0cc47af7f61c
spec:
  action: stop
  cpus: 4
  hosted_novnc: true
  image: rancher/vm-ubuntu:16.04.4-server-amd64
  image_vmtools: nsonetwork30/vm-tools
  kvm_extra_args: -cpu host -device vfio-pci,host=81:00.3 -mem-prealloc -mem-path
    /hugepages
  memory_mb: 1024
  node_name: ""
  public_keys:
  - jerome
  use_hugepages: true
status:
  id: i-6ac30d2a
  ip: ""
  mac: 06:fe:6a:c3:0d:2a
  node_ip: xx.xx.xx.xx
  node_name: ""
  state: stopped
  vnc_endpoint: xx.xx.xx.xx:31490
```