### PR TITLE
add 2 vm properties to allow storage persistence

### DIFF
--- a/pkg/apis/ranchervm/v1alpha1/types.go
+++ b/pkg/apis/ranchervm/v1alpha1/types.go
@@ -51,7 +51,8 @@ type VirtualMachineSpec struct {
         KvmArgs string `json:"kvm_extra_args"`
         ImageVMTools string `json:"image_vmtools"`
         UseHugePages bool `json:"use_hugepages"`
-
+        VmImagePvc string `json:"image_pvc"`
+        VmVolumesPvc string `json:"volumes_pvc"`
 }
 
 type StateType string

--- a/pkg/apis/ranchervm/v1alpha1/types.go
+++ b/pkg/apis/ranchervm/v1alpha1/types.go
@@ -51,8 +51,8 @@ type VirtualMachineSpec struct {
         KvmArgs string `json:"kvm_extra_args"`
         ImageVMTools string `json:"image_vmtools"`
         UseHugePages bool `json:"use_hugepages"`
-        VmImagePvc string `json:"image_pvc"`
-        VmVolumesPvc string `json:"volumes_pvc"`
+        VmImagePvcName string `json:"image_pvc"`
+        VmVolumesPvcName string `json:"volumes_pvc"`
 }
 
 type StateType string

--- a/pkg/common/util.go
+++ b/pkg/common/util.go
@@ -110,3 +110,14 @@ func MakeHostStateVol(vmName, volName string) corev1.Volume {
 		},
 	}
 }
+
+func MakePvcVol(name, pvcname string) corev1.Volume {
+	return corev1.Volume{
+		Name: name,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvcname,
+			},
+		},
+	}
+}


### PR DESCRIPTION
in the VM spec
  image_pvc: name of an existing pvc to persist changes done on the first virtual drive (mounted on /image)
  volumes_pvc: name of an existing pvc to persist changes done on additional virtual drives (mounted on /volumes)

Signed-off-by: jdoucerain <jerome.doucerain@bell.ca>